### PR TITLE
Minor updates

### DIFF
--- a/VRRenderer.js
+++ b/VRRenderer.js
@@ -83,6 +83,7 @@ THREE.VRRenderer = function(renderer, hmd) {
         renderer.setViewport(width, 0, width, height);
         renderer.setScissor(width, 0, width, height);
         renderer.render(scene, cameraRight);
+        renderer.enableScissorTest(false);
     }
 
     self.initialize();

--- a/VRRenderer.js
+++ b/VRRenderer.js
@@ -7,8 +7,13 @@ THREE.VRRenderer = function(renderer, hmd) {
     self.initialize = function() {
         var et = hmd.getEyeTranslation("left");
         self.halfIPD = new THREE.Vector3(et.x, et.y, et.z).length();
-        self.fovLeft = hmd.getRecommendedEyeFieldOfView("left");
-        self.fovRight = hmd.getRecommendedEyeFieldOfView("right");
+        if ('getCurrentEyeFieldOfView' in hmd) {
+            self.fovLeft = hmd.getCurrentEyeFieldOfView("left");
+            self.fovRight = hmd.getCurrentEyeFieldOfView("right");
+        } else {
+            self.fovLeft = hmd.getRecommendedEyeFieldOfView("left");
+            self.fovRight = hmd.getRecommendedEyeFieldOfView("right");
+        }
     }
 
     self.FovToNDCScaleOffset = function(fov) {


### PR DESCRIPTION
A couple updates that might be useful:
- Defaults to using getCurrentEyeFieldOfView, and falls back to getRecommendedEyeFieldOfView if not available
- Disables scissor testing after rendering in case you go back to rendering without VRRenderer
